### PR TITLE
Version 1.1.0. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ from the namespace blueN, and the device vethrealN is visible from the host. The
 
 ## Prerequisites
 
-* A Linux host with root privilleges (use a dedicated virtual machine to stay safe)
+* A Linux host with a 5.x+ kernel and root privilleges  (use a dedicated virtual machine to stay safe)
 * The following Debian packages (or equivivalent):
 
 ```
@@ -56,13 +56,15 @@ sudo sysctl -p /etc/sysctl.conf
 
 [more info on how to make the ip forwarding change permanent](https://askubuntu.com/questions/311053/how-to-make-ip-forwarding-permanent)
 
-## Installing
+* You need a working nodejs and npm setup if you intend to install the scripts globally using npm. Alternatively you can directly execute the scripts from the bin folder 
+
+## Installing using npm
 
 ```
 sudo npm install -g @streamr/lnem
 ```
 
-## Uninstalling
+## Uninstalling using npm
 
 ```
 sudo npm uninstall -g @streamr/lnem
@@ -78,8 +80,8 @@ Install netperf
 sudo apt-get install netperf
 ```
 
-Create a network namespace for the netperf server with download bandwidth limit of 1000 kbit/s, upload bandwidth limit of 2000 kbit/s, and RTT latency 
-of 10 ms between the namespace and the host machine.
+Create a network namespace for the netperf server with download bandwidth limit of 1000 kbit/s, upload bandwidth limit of 2000 kbit/s, and
+one-way latency of 10 ms between the namespace and the host machine.
 
 ```
 sudo lnem-up --download 1000 --upload 2000 --latency 10 --num 1
@@ -101,7 +103,7 @@ sudo ip netns exec blue2 ping 10.240.1.2
 Start the netperf server in the blue1 namespace
 
 ```
-sudo ip netns exec blue1 netserver  &
+sudo ip netns exec blue1 netserver -4 &
 ```
 
 
@@ -109,7 +111,7 @@ Run the netperf client in the blue2 namespace, and instruct it to connect to the
 be close to 1 Mibit/s (the download bandwidth limit we set to the server's namespace)
 
 ```
-sudo ip netns exec blue2 netperf -H 10.240.1.2 
+sudo ip netns exec blue2 netperf -4 -H 10.240.1.2 
 ```
 
 To clean up, kill netperf server, and delete the two namespaces.
@@ -122,6 +124,6 @@ sudo lnem-down -n 2
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE.md](LICENSE.md) file for details
+This project is licensed under the MIT License.
 
 

--- a/bin/lnem-up
+++ b/bin/lnem-up
@@ -58,7 +58,7 @@ LAST_INTERFACE=$(( $FIRST_INTERFACE + $NUM_INTERFACES - 1 ))
 echo "Creating $NUM_INTERFACES network namespaces blue$FIRST_INTERFACE...blue$LAST_INTERFACE"
 echo "Upload to host bandwidth limit $ULSPEED kbit/s"
 echo "Download from host bandwidth limit $DLSPEED kbit/s"
-echo "RTT latency to host $ONEWAYDELAY ms"
+echo "One-way latency to/from host $ONEWAYDELAY ms"
 
 
 smallcounter=1
@@ -107,54 +107,56 @@ for (( c=${FIRST_INTERFACE}; c<=${LAST_INTERFACE}; c++ ))
 
 		#Set upload and download limits to vethvirtualX
 
-		if [[ "$DLSPEED" != "0" || "$ULSPEED" != "0" ]];
-		 then
-		 	sudo tc qdisc add dev vethreal${c} root handle 1: htb default 30
-			sudo ip netns exec blue${c} tc qdisc add dev vethvirtual${c} root handle 1: htb default 30
-			
-		 else
-		 	if [ $ONEWAYDELAY != "0" ]
-		 	 then
-		 		sudo ip netns exec blue${c} tc qdisc add dev vethvirtual${c} root netem delay ${ONEWAYDELAY}ms
-		 	fi
-		fi
-		
-		if [ "$DLSPEED" != "0" ]
-		 then		
-			
-			sudo tc class add dev vethreal${c} parent 1: classid 1:1 htb rate ${DLSPEED}kbit
-			sudo tc filter add dev vethreal${c} protocol ip parent 1:0 prio 1 u32 match ip dst ${virtualip}/32 flowid 1:1
-			
-		fi
-		
-		if [ "$ULSPEED" != "0" ]
-		 then
-                	sudo ip netns exec blue${c} tc class add dev vethvirtual${c} parent 1: classid 1:2 htb rate ${ULSPEED}kbit
-                	sudo ip netns exec blue${c} tc filter add dev vethvirtual${c} protocol ip parent 1:0 prio 1 u32 match ip src ${virtualip}/32 flowid 1:2
-		fi
+		#Uplink
 		
 		if [ "$ONEWAYDELAY" != "0" ]
- 		 then
- 		 	if  [ "$DLSPEED" != "0" ]
- 		 	 then
-				sudo tc qdisc add dev vethreal${c} parent 1:1 handle 11 netem delay ${ONEWAYDELAY}ms
-			 else
-			 	if [ "$ULSPEED" != "0" ]
-			 	 then
-			 	 	sudo ip netns exec blue${c} tc qdisc add dev vethvirtual${c} parent 1:2 handle 12 netem delay ${ONEWAYDELAY}ms
-			 	 	
-			 	fi
-			fi
+                 then
+                        sudo ip netns exec blue${c} tc qdisc add dev vethvirtual${c} root handle 1: netem delay ${ONEWAYDELAY}ms
+                        
+                        if [ "$ULSPEED" != "0" ]
+                         then
+                                sudo ip netns exec blue${c} tc qdisc add dev vethvirtual${c} parent 1: cake bandwidth ${ULSPEED}kbit besteffort
+                        fi
+                        
+                 else
+                 	  
+                	if [ "$ULSPEED" != "0" ]
+                 	 then
+                        	sudo ip netns exec blue${c} tc qdisc add dev vethvirtual${c} root cake bandwidth ${ULSPEED}kbit besteffort
+                	fi
+                fi
+                
+		
+		#Downlink 	
 			
-		fi
+		sudo ip netns exec blue${c} ip link add name ifb${c} type ifb
+		sudo ip netns exec blue${c} tc qdisc add dev vethvirtual${c} handle ffff: ingress
 		
 		
+		if [ "$ONEWAYDELAY" != "0" ]
+                 then
+                	sudo ip netns exec blue${c} tc qdisc add dev ifb${c} root handle 2: netem delay ${ONEWAYDELAY}ms	
+                
+                	if [ "$DLSPEED" != "0" ]
+                         then
+                                sudo ip netns exec blue${c} tc qdisc add dev ifb${c} parent 2: cake bandwidth ${DLSPEED}kbit besteffort 
+                        fi
+                 else
+                 	
+                 	if [ "$DLSPEED" != "0" ]
+                  	 then	
+				sudo ip netns exec blue${c} tc qdisc add dev ifb${c} root cake bandwidth ${DLSPEED}kbit besteffortt
+			fi
+		fi 	
+		
+		sudo ip netns exec blue${c} ip link set ifb${c} up # if you don't bring the device up your connection will lock up on the next step.
+		sudo ip netns exec blue${c} tc filter add dev vethvirtual${c} parent ffff: matchall action mirred egress redirect dev ifb${c}
+		
+				
 		#Add static route from host towards the virtual device
 		
 		sudo route add -net ${network} netmask 255.255.255.0 gw ${realip} dev vethreal${c}
 
-	
-		#sudo ip netns exec blue${c} ../../setupdbus.sh
 				
 		#Update counters for ip address generation
 

--- a/bin/lnem-up
+++ b/bin/lnem-up
@@ -145,7 +145,7 @@ for (( c=${FIRST_INTERFACE}; c<=${LAST_INTERFACE}; c++ ))
                  	
                  	if [ "$DLSPEED" != "0" ]
                   	 then	
-				sudo ip netns exec blue${c} tc qdisc add dev ifb${c} root cake bandwidth ${DLSPEED}kbit besteffortt
+				sudo ip netns exec blue${c} tc qdisc add dev ifb${c} root cake bandwidth ${DLSPEED}kbit besteffort
 			fi
 		fi 	
 		

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamr/lnem",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Lightweight Network EMulator",
   "bin": {
   "lnem-up": "./bin/lnem-up",


### PR DESCRIPTION
Switched to using 'cake' qdisc for traffic shaping. Requires kernel version 5+.
Changed the command line parameters to use one-way latency instead of RTT.